### PR TITLE
Update zae-limiter to 0.10.2

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: zae-limiter
-  version: "0.10.1"
+  version: "0.10.2"
   python_min: "3.11"
 
 package:
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/z/${{ name }}/zae_limiter-${{ version }}.tar.gz
-  sha256: df2407e968761ea89870bcf8bc1d1c01366f607b287fa8e096dd6628cf42329f
+  sha256: 5fe3c9a2c483c801bdd8152580901dd4f3275431868694fc764aac5d579a72ae
 
 build:
   noarch: python
@@ -26,7 +26,7 @@ requirements:
     - ruff >=0.9.0
   run:
     - python >=${{ python_min }}
-    - aioboto3 >=12.0.0
+    - aiobotocore >=2.13.0
     - aws_lambda_builders >=1.40.0
     - boto3 >=1.34.0
     - click >=8.0.0


### PR DESCRIPTION
Updates `zae-limiter` to **0.10.2**.

## Changes
- Bump `version` 0.10.1 → 0.10.2; update `sha256` (verified against the PyPI sdist `zae_limiter-0.10.2.tar.gz`).
- Replace runtime dependency `aioboto3 >=12.0.0` with `aiobotocore >=2.13.0`, matching the upstream `requires_dist` change in 0.10.2.
- Build number is 0 (version bump).

## Checklist
- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (to 0, since the version changed)
- [x] Reset the build number to 0 (specifically for version changes)
- [x] Re-rendered with the latest conda-smithy (not required — version/dependency bump only, no CI matrix changes)
- [x] Ensured the license file is being packaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)