### PR TITLE
Update zae-limiter to 0.10.3

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: zae-limiter
-  version: "0.10.2"
+  version: "0.10.3"
   python_min: "3.11"
 
 package:
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/z/${{ name }}/zae_limiter-${{ version }}.tar.gz
-  sha256: 5fe3c9a2c483c801bdd8152580901dd4f3275431868694fc764aac5d579a72ae
+  sha256: d96316cb72f20542088e6ce697ba9b2206539b0088a04e4d7f36096095312eba
 
 build:
   noarch: python


### PR DESCRIPTION
Updates `zae-limiter` to **0.10.3**.

## Changes
- Bump `version` 0.10.2 → 0.10.3; update `sha256` (verified against the PyPI sdist `zae_limiter-0.10.3.tar.gz`).
- No dependency changes from upstream.
- Build number is 0 (version bump).

## Checklist
- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped/reset the build number to 0 (version change)
- [x] Re-rendered with the latest conda-smithy (not required — version bump only, no CI matrix changes)
- [x] Ensured the license file is being packaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)